### PR TITLE
Add git clone submodules in debian/ubuntu instructions

### DIFF
--- a/resources/docs/compguide.md
+++ b/resources/docs/compguide.md
@@ -30,6 +30,7 @@ Now run the following:
 ```bash
 git clone https://www.github.com/pound-emu/pound.git
 cd pound
+git submodule update --init --recursive
 ```
 
 and then:


### PR DESCRIPTION
Unlike the Arch Linux build instructions, Ubuntu/Debian instructions don't mention cloning submodules. We do se here.