### PR TITLE
Build & Run support for MacOS ARM

### DIFF
--- a/core/JIT/jit.cpp
+++ b/core/JIT/jit.cpp
@@ -48,11 +48,19 @@ void JIT::translate_and_run(CPU& cpu) {
 
     JitFunc fn = reinterpret_cast<JitFunc>(code);
     u64 result;
+#if defined(__x86_64__)
     asm volatile("call *%1\n"
                  "mov %%rax, %0\n"
                  : "=r"(result)
                  : "r"(fn)
                  : "%rax");
+#elif defined(__aarch64__)
+        asm volatile("blr %1\n"
+                     "mov %0, x0\n"
+                     : "=r"(result)
+                     : "r"(fn)
+                     : "x0");
+#endif
 
     cpu.regs[0] = result;
 }

--- a/gui/gui.cpp
+++ b/gui/gui.cpp
@@ -137,7 +137,13 @@ bool gui::init_imgui(gui::window_t* main_window)
         return false;
     }
 
+#ifdef __APPLE__ && (__aarch64__)
+    ret = ::ImGui_ImplOpenGL3_Init("#version 120");
+#elif __APPLE__ && (__x86_64__)
+    ret = ::ImGui_ImplOpenGL3_Init("#version 150");
+#else
     ret = ::ImGui_ImplOpenGL3_Init("#version 330");
+#endif
     if (false == ret)
     {
         LOG_ERROR(Render, "Failed to init OpenGL3: {}", SDL_GetError());


### PR DESCRIPTION
Hello,

I added support for building the project on MacOS ARM by adding ARM assembly support in the JIT translate_and_run function.

Now, the app crashes on startup with this error, I will investigate this in the near future :)

```
ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile vertex shader! With GLSL: #version 330

ERROR: 0:1: '' :  version '330' is not supported
```

(First PR here, don't hesitate to tell me if something is wrong etc)