### PR TITLE
Minor Changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          brew install ninja llvm
+          brew install llvm
 
       - name: Configure CMake (x86_64)
         run: >
@@ -156,7 +156,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          brew install ninja llvm
+          brew install llvm
 
       - name: Configure CMake (ARM64)
         run: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ foreach(line ${submodule_lines})
         if(submodule_path STREQUAL "3rd_Party/imgui")
             verify_pinned_commit("imgui" "${submodule_path}" "${commit_hash}" "bf75bfec48fc00f532af8926130b70c0e26eb099")
         elseif(submodule_path STREQUAL "3rd_Party/SDL3")
-            verify_pinned_commit("SDL3" "${submodule_path}" "${commit_hash}" "a8589a84226a6202831a3d49ff4edda4acab9acd")
+            verify_pinned_commit("SDL3" "${submodule_path}" "${commit_hash}" "a96677bdf6b4acb84af4ec294e5f60a4e8cbbe03")
         endif()
 
         message(STATUS "Verified submodule: ${submodule_path} (${commit_hash})")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.25)
 
 #------------------------
 # ---- Project Setup ----
@@ -79,7 +79,7 @@ foreach(line ${submodule_lines})
         if(submodule_path STREQUAL "3rd_Party/imgui")
             verify_pinned_commit("imgui" "${submodule_path}" "${commit_hash}" "bf75bfec48fc00f532af8926130b70c0e26eb099")
         elseif(submodule_path STREQUAL "3rd_Party/SDL3")
-            verify_pinned_commit("SDL3" "${submodule_path}" "${commit_hash}" "a96677bdf6b4acb84af4ec294e5f60a4e8cbbe03")
+            verify_pinned_commit("SDL3" "${submodule_path}" "${commit_hash}" "a8589a84226a6202831a3d49ff4edda4acab9acd")
         endif()
 
         message(STATUS "Verified submodule: ${submodule_path} (${commit_hash})")
@@ -107,10 +107,6 @@ add_subdirectory(src/targets/switch1/hardware)
 # ---- Target Configurations ----
 #--------------------------------
 
-if(WIN32)
-    add_compile_options(-DNOMINMAX -DWIN32_LEAN_AND_MEAN)
-endif()
-
 include(TestBigEndian)
 TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
 
@@ -133,6 +129,11 @@ foreach(TARGET ${POUND_PROJECT_TARGETS})
         -Wconversion>
     )
 
+    if(WIN32)
+        target_compile_options(${TARGET} PRIVATE -DNOMINMAX -DWIN32_LEAN_AND_MEAN)
+        target_compile_definitions(${TARGET} PRIVATE _CRT_SECURE_NO_WARNINGS) # Disable some Windows SDK deprecation warnings
+    endif()
+
     # Set Compile time log level for all targets.
     # 1: Trace
     # 2: Debug
@@ -145,10 +146,6 @@ endforeach()
 
 # Optimizations
 set_property(TARGET Pound PROPERTY CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
-if (WIN32)
-    target_compile_options(Pound PRIVATE $<$<CONFIG:Release>:/Oi>)
-    target_compile_options(Pound PRIVATE  $<$<CONFIG:Release>:/Ot>)
-endif()
 
 target_link_libraries(Pound PRIVATE
     common

--- a/src/common/passert.h
+++ b/src/common/passert.h
@@ -1,7 +1,7 @@
 #ifndef POUND_COMMON_ASSERT_H
 #define POUND_COMMON_ASSERT_H
 
-__attribute__((noreturn)) void pound_internal_assert_fail(const char* file, int line, const char* func,
+[[noreturn]] void pound_internal_assert_fail(const char* file, int line, const char* func,
                                                           const char* expr_str, const char* user_msg, ...);
 
 #define PVM_ASSERT(expression)                                                                             \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ int main()
 
     if (bool return_code = gui::init_imgui(&window); false == return_code)
     {
-        LOG_ERROR( "Failed to initialize GUI");
+        LOG_ERROR("Failed to initialize GUI");
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
## Description
- Removing `ninja` from macOS deps because it's making an CI warning (already installed)
- Bumping minimum CMake version to 3.25 (This version include C++23 standard)
- Removing /Oi and /Ot flags because already included with /O2 flag (Release mode)
- Changing `__attribute__((noreturn))` by `[[noreturn]]` for more portable code
- Update SDL3 from `3.2.22` to `3.2.24` -> [Release Note](https://github.com/libsdl-org/SDL/releases/tag/release-3.2.24)
- Adding `_CRT_SECURE_NO_WARNINGS` definition for avoiding Windows SDK deprecation warnings

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Refactoring (no functional change, code cleanup)
- [ ] Performance improvement

## Code Review Process
**IMPORTANT**: This project maintains an extremely high standard for code quality and correctness. By submitting this pull request, you acknowledge and agree to the following:

1. **You must be able to defend every single line of code you have added or modified**
2. **You must be prepared to explain the reasoning behind every design decision**
3. **You must be able to discuss and justify your approach to solving the problem**
4. **You must be ready to address all feedback and make requested changes**
5. **You must have thoroughly tested your changes and be confident in their correctness**

The code review process for this project is intentionally tedious and thorough. Do not submit a pull request unless you are prepared to defend your PR changes.

## Breaking Changes
If this change introduces any breaking changes, please describe them here.

## Checklist
- [X] My code follows the project's coding style guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have read the project's CONTRIBUTING guidelines
- [X] I understand and agree to the rigorous code review process described above