### PR TITLE
jit: add logging for ARM32 instruction registration

### DIFF
--- a/src/jit/decoder/arm32.cpp
+++ b/src/jit/decoder/arm32.cpp
@@ -85,7 +85,13 @@ void arm32_add_instruction(arm32_decoder_t* decoder, const char* name, const cha
     }
 
     ++decoder->instruction_count;
-    arm32_log_instruction_info(info);
+    LOG_TRACE("========================================");
+    LOG_TRACE("Instruction Registered: %s", info->name);
+    LOG_TRACE("Mask:      0x%08X", info->mask);
+    LOG_TRACE("Expected:  0x%08X", info->expected);
+    LOG_TRACE("Priority:  %d", info->priority);
+    LOG_TRACE("========================================");
+
 
     /* TODO(GloriousTacoo:jit): Add instruction to lookup table. */
 }
@@ -132,19 +138,5 @@ void arm32_parse_bitstring(const char* bitstring, uint32_t* mask, uint32_t* expe
         }
     }
 }
-void arm32_log_instruction_info(const arm32_instruction_info_t* info)
-{
-    if (info == nullptr)
-    {
-        LOG_TRACE("Attempted to log a null instruction info pointer!");
-        return;
-    }
 
-    LOG_TRACE("========================================");
-    LOG_TRACE("Instruction Registered: %s", info->name);
-    LOG_TRACE("Mask:      0x%08X", info->mask);
-    LOG_TRACE("Expected:  0x%08X", info->expected);
-    LOG_TRACE("Priority:  %d", info->priority);
-    LOG_TRACE("========================================");
-}
 }  // namespace pound::jit::decoder

--- a/src/jit/decoder/arm32.cpp
+++ b/src/jit/decoder/arm32.cpp
@@ -60,13 +60,9 @@ void arm32_add_instruction(arm32_decoder_t* decoder, const char* name, const cha
     PVM_ASSERT(nullptr != bitstring);
     PVM_ASSERT(decoder->instruction_count < decoder->instruction_capacity);
 
-    LOG_TRACE("Adding '%s' instruction to lookup table.", name);
     arm32_opcode_t mask = 0;
     arm32_opcode_t expected = 0;
     arm32_parse_bitstring(bitstring, &mask, &expected);
-
-    LOG_TRACE("Mask: %x", mask);
-    LOG_TRACE("Expected: %x", expected);
 
     arm32_instruction_info_t* info = &decoder->instructions[decoder->instruction_count];
     info->name = name;

--- a/src/jit/decoder/arm32.cpp
+++ b/src/jit/decoder/arm32.cpp
@@ -85,6 +85,7 @@ void arm32_add_instruction(arm32_decoder_t* decoder, const char* name, const cha
     }
 
     ++decoder->instruction_count;
+    arm32_log_instruction_info(info);
 
     /* TODO(GloriousTacoo:jit): Add instruction to lookup table. */
 }
@@ -130,5 +131,20 @@ void arm32_parse_bitstring(const char* bitstring, uint32_t* mask, uint32_t* expe
                 PVM_ASSERT_MSG(false, "Invalid bitstring character: %c", bitstring[i]);
         }
     }
+}
+void arm32_log_instruction_info(const arm32_instruction_info_t* info)
+{
+    if (info == nullptr)
+    {
+        LOG_TRACE("Attempted to log a null instruction info pointer!");
+        return;
+    }
+
+    LOG_TRACE("========================================");
+    LOG_TRACE("Instruction Registered: %s", info->name);
+    LOG_TRACE("Mask:      0x%08X", info->mask);
+    LOG_TRACE("Expected:  0x%08X", info->expected);
+    LOG_TRACE("Priority:  %d", info->priority);
+    LOG_TRACE("========================================");
 }
 }  // namespace pound::jit::decoder

--- a/src/jit/decoder/arm32.h
+++ b/src/jit/decoder/arm32.h
@@ -48,7 +48,6 @@ void arm32_add_instruction(arm32_decoder_t* decoder, const char* name, arm32_opc
                            arm32_handler_fn handler);
 void arm32_ADD_imm_handler(arm32_decoder_t* decoder, arm32_instruction_t instruction);
 
-void arm32_log_instruction_info(const arm32_instruction_info_t* info);
 
 }  // namespace pound::jit::decoder
 #endif  // POUND_JIT_DECODER_ARM32_H

--- a/src/jit/decoder/arm32.h
+++ b/src/jit/decoder/arm32.h
@@ -48,5 +48,7 @@ void arm32_add_instruction(arm32_decoder_t* decoder, const char* name, arm32_opc
                            arm32_handler_fn handler);
 void arm32_ADD_imm_handler(arm32_decoder_t* decoder, arm32_instruction_t instruction);
 
+void arm32_log_instruction_info(const arm32_instruction_info_t* info);
+
 }  // namespace pound::jit::decoder
 #endif  // POUND_JIT_DECODER_ARM32_H


### PR DESCRIPTION
Added `arm32_log_instruction_info()` for detailed logging of ARM32 instructions during registration.  
Improves debugging and trace clarity without changing functionality.

## **Type of Change**
- [x] Refactoring (no functional change, code cleanup)  
- [x] Documentation update  

## **Checklist**
- [x] My code follows the project's coding style  
- [x] I have commented my code clearly  
- [x] The project still builds successfully  