### PR TITLE
Fix misplaced whitespace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 
 Join the [**Pound Discord Server**](https://discord.gg/aMmTmKsVC7)!
 
-**Pound** is an early-stage emulator for the **Nintendo Switch 1 and hopefully Switch 2**, targeting **Windows**, **Linux** and **macOS** (
-Intel and Apple Silicon).
+**Pound** is an early-stage emulator for the **Nintendo Switch 1 and hopefully Switch 2**, targeting **Windows**, **Linux** and **macOS** (Intel and Apple Silicon).
 
 Initial focus is on implementing the architectural similarities to the original Nintendo Switch. Later stages of
 development will address differences in hardware between the two console generations.


### PR DESCRIPTION
## Description

I removed a whitespace between the opening parenthesis and the I in Intel (from "( Intel" to "(Intel")

## Type of Change
(feels a bit excessive for a 1 byte removal in the README...)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change, code cleanup)
- [ ] Performance improvement

## Code Review Process

**IMPORTANT**: This project maintains an extremely high standard for code quality and correctness. By submitting this
pull request, you acknowledge and agree to the following:

1. **You must be able to defend every single line of code you have added or modified**
2. **You must be prepared to explain the reasoning behind every design decision**
3. **You must be able to discuss and justify your approach to solving the problem**
4. **You must be ready to address all feedback and make requested changes**
5. **You must have thoroughly tested your changes and be confident in their correctness**

The code review process for this project is intentionally tedious and thorough. Do not submit a pull request unless you
are prepared to defend your PR changes.

## Breaking Changes

If this change introduces any breaking changes, please describe them here.

## Checklist

- [x] My code follows the project's coding style guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have read the project's CONTRIBUTING guidelines
- [x] I understand and agree to the rigorous code review process described above
