### PR TITLE
[98] cmake: load mimalloc before the Windows CRT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,12 +172,18 @@ add_library(PoundGui SHARED
         src/gui/render/debug_memory_tracker.c
         src/gui/render/debug_memory_tracker_gui_box.c)
 target_include_directories(PoundGui PUBLIC src/gui)
-target_link_libraries(PoundGui PRIVATE PoundCore imgui mimalloc)
+# Windows loads PoundGui before the EXE finishes its own imports. Listing
+# mimalloc ahead of imgui keeps mimalloc-redirect ahead of ucrt in
+# PoundGui's import table.
+target_link_libraries(PoundGui PRIVATE mimalloc PoundCore imgui)
 set_target_properties(PoundGui PROPERTIES C_VISIBILITY_PRESET hidden)
 set_target_properties(PoundGui PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 if (WIN32)
     # MSVC/clang-cl do not prefix DLLs with "lib"; the loader looks for libPoundGui.dll.
     set_target_properties(PoundGui PROPERTIES PREFIX "lib")
+endif ()
+if (MSVC)
+    target_link_options(PoundGui PRIVATE "/INCLUDE:mi_version")
 endif ()
 add_compiler_flags(PoundGui)
 add_linker_flags(PoundGui)
@@ -187,7 +193,11 @@ message(STATUS "[Pound] Configuring Pound Executable...")
 
 add_executable(${PROJECT_NAME} src/main.c)
 target_include_directories(${PROJECT_NAME} PRIVATE src/)
-target_link_libraries(${PROJECT_NAME} PRIVATE PoundCore PoundGui Ballistic::Engine mimalloc SDL3::SDL3 imgui)
+target_link_libraries(${PROJECT_NAME} PRIVATE mimalloc PoundCore PoundGui Ballistic::Engine SDL3::SDL3 imgui)
+if (MSVC)
+    # Keep mimalloc.dll mapped so redirect can override malloc for the whole process.
+    target_link_options(${PROJECT_NAME} PRIVATE "/INCLUDE:mi_version")
+endif ()
 target_compile_definitions(${PROJECT_NAME} PUBLIC -DCIMGUI_USE_OPENGL3 -DCIMGUI_USE_SDL3)
 add_compiler_flags(${PROJECT_NAME})
 add_linker_flags(${PROJECT_NAME})


### PR DESCRIPTION
## Description

Fixes issue #98. Requires PR #99 to compile.

Windows loads `PoundGui` before the EXE finishes its own imports.
If that DLL imports imgui/ucrt before mimalloc, `mimalloc-redirect`
never takes over and tracker stats stay ~0.

Link mimalloc first on `PoundGui` and keep it mapped with
`/INCLUDE:mi_version`.

<img width="1262" height="757" alt="Screenshot 2026-08-19 041135" src="https://github.com/user-attachments/assets/95db2df7-64da-4a09-ab8a-b2a8a62a8a24" />

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)