### PR TITLE
[95] gui: report .text and .data ranges on Windows

### DIFF
--- a/src/gui/debug/debug_memory_data.c
+++ b/src/gui/debug/debug_memory_data.c
@@ -113,6 +113,46 @@ debug_memory_get_host_address_space_range(debug_memory_tracker_t *context)
             }
 
             ++matched_regions;
+
+            if (true == is_self && MEM_COMMIT == info.State)
+            {
+                const DWORD protect_type = info.Protect & 0xFF;
+
+                if (PAGE_EXECUTE_READ == protect_type || PAGE_EXECUTE == protect_type
+                    || PAGE_EXECUTE_WRITECOPY == protect_type)
+                {
+                    if (UINT64_MAX == text_start)
+                    {
+                        text_start = start_hex;
+                        text_end   = end_hex;
+                    }
+                    else if (start_hex == text_end)
+                    {
+                        text_end = end_hex;
+                    }
+                    else
+                    {
+                    }
+                }
+                else if (PAGE_READWRITE == protect_type || PAGE_WRITECOPY == protect_type)
+                {
+                    if (UINT64_MAX == data_start)
+                    {
+                        data_start = start_hex;
+                        data_end   = end_hex;
+                    }
+                    else if (start_hex == data_end)
+                    {
+                        data_end = end_hex;
+                    }
+                    else
+                    {
+                    }
+                }
+                else
+                {
+                }
+            }
         }
 
         if (region_end <= address)


### PR DESCRIPTION
## Description

The .text and .data boxes stay unknown on Windows because the VirtualQuery walk only records the overall span. Linux already classifies the exe's r-x and rw- mappings.

This matches that on committed pages of the main image using protect flags. A range grows only when the next matching page is contiguous, so .tls does not swallow the pages between it and .data.

<img width="1260" height="752" alt="Screenshot 2026-08-27 042758" src="https://github.com/user-attachments/assets/e47d8b61-9791-4370-ad33-592ad04c660f" />
<img width="1262" height="755" alt="Screenshot 2026-08-27 042753" src="https://github.com/user-attachments/assets/920839cd-29fa-4d3f-a5b4-dc970f58e6a0" />


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)